### PR TITLE
Fix tzwin encoding errors

### DIFF
--- a/dateutil/tzwin.py
+++ b/dateutil/tzwin.py
@@ -4,6 +4,8 @@ import struct
 
 from six.moves import winreg
 
+from .tz import tzname_in_python2
+
 __all__ = ["tzwin", "tzwinlocal"]
 
 ONEWEEK = datetime.timedelta(7)
@@ -42,6 +44,7 @@ class tzwinbase(datetime.tzinfo):
         else:
             return datetime.timedelta(0)
 
+    @tzname_in_python2
     def tzname(self, dt):
         if self._isdst(dt):
             return self._dstname
@@ -89,8 +92,8 @@ class tzwin(tzwinbase):
                                 "%s\%s" % (TZKEYNAME, name)) as tzkey:
                 keydict = valuestodict(tzkey)
 
-        self._stdname = keydict["Std"].encode("iso-8859-1")
-        self._dstname = keydict["Dlt"].encode("iso-8859-1")
+        self._stdname = keydict["Std"]
+        self._dstname = keydict["Dlt"]
 
         self._display = keydict["Display"]
 
@@ -129,8 +132,8 @@ class tzwinlocal(tzwinbase):
             with winreg.OpenKey(handle, TZLOCALKEYNAME) as tzlocalkey:
                 keydict = valuestodict(tzlocalkey)
 
-            self._stdname = keydict["StandardName"].encode("iso-8859-1")
-            self._dstname = keydict["DaylightName"].encode("iso-8859-1")
+            self._stdname = keydict["StandardName"]
+            self._dstname = keydict["DaylightName"]
 
             try:
                 with winreg.OpenKey(


### PR DESCRIPTION
Stop encoding `_dstname` and `_stdname` to bytes with `iso-8859-1`, because we cannot assume that's the
correct codepage. Uses the current solution we use in `tz.py`, which outputs unicode in Python3.
Fixes #92  and http://stackoverflow.com/questions/21296475/python-dateutil-unicode-warning
and https://bugs.launchpad.net/dateutil/+bug/1227221
